### PR TITLE
Give cropped layers unique names

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,7 +3,7 @@
 
 name: tests
 
-on: 
+on:
   push:
     branches:
       - master
@@ -46,7 +46,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       # note: if you need dependencies from conda, considering using
@@ -69,7 +69,7 @@ jobs:
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
-    # and requires that you have put your twine API key in your 
+    # and requires that you have put your twine API key in your
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -20,7 +20,7 @@ def crop_region(
     viewer: 'napari.viewer.Viewer',
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
-) -> List[LayerDataTuple]:# napari.layers.Layer: #
+) -> List[LayerDataTuple]:
     """Crop regions in napari defined by shapes."""
     if shapes_layer is None:
         shapes_layer.mode = "add_rectangle"

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -17,9 +17,9 @@ def napari_experimental_provide_function():
 
 @register_function(menu="Utilities > Crop region(s)")
 def crop_region(
-    viewer: 'napari.viewer.Viewer',
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
+    viewer: 'napari.viewer.Viewer' = None, 
 ) -> List[LayerDataTuple]:
     """Crop regions in napari defined by shapes."""
     if shapes_layer is None:

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -7,6 +7,7 @@ import napari
 from napari.types import LayerDataTuple
 from typing import List
 
+
 # This is the actual plugin function, where we export our function
 # (The functions themselves are defined below)
 @napari_hook_implementation
@@ -16,9 +17,10 @@ def napari_experimental_provide_function():
 
 @register_function(menu="Utilities > Crop region(s)")
 def crop_region(
+    viewer: 'napari.viewer.Viewer',
     layer: napari.layers.Layer,
     shapes_layer: napari.layers.Shapes,
-) -> List[LayerDataTuple]:
+) -> List[LayerDataTuple]:# napari.layers.Layer: #
     """Crop regions in napari defined by shapes."""
     if shapes_layer is None:
         shapes_layer.mode = "add_rectangle"
@@ -42,7 +44,12 @@ def crop_region(
     shape_types = shapes_layer.shape_type
     shapes = shapes_layer.data
     cropped_list = []
-    for count, [shape, shape_type] in enumerate(zip(shapes, shape_types)):
+    new_layer_index = 0
+    new_name = layer_props["name"] + " cropped [0]"
+    # Get existing layer names in viewer
+    names_list = [layer.name for layer in viewer.layers]
+    for shape_count, [shape, shape_type] in enumerate(zip(shapes,
+                                                          shape_types)):
         # move shape vertices to within image coordinate limits
         layer_shape = np.array(layer_data.shape)
         if rgb:
@@ -101,6 +108,16 @@ def crop_region(
             cropped_data = cropped_data[tuple(indices)]
 
         new_layer_props = layer_props.copy()
-        new_layer_props["name"] = layer_props["name"] + f" (cropped {count+1})"
+        # If layer name is in viewer or is about to be added,
+        # give it a different name
+        while True:
+            new_name = layer_props["name"] \
+                + f" cropped [{shape_count+new_layer_index}]"
+            if new_name not in names_list:
+                break
+            else:
+                new_layer_index += 1
+        new_layer_props["name"] = new_name
+        names_list.append(new_name)
         cropped_list.append((cropped_data, new_layer_props, layer_type))
     return cropped_list

--- a/napari_crop/_function.py
+++ b/napari_crop/_function.py
@@ -46,8 +46,10 @@ def crop_region(
     cropped_list = []
     new_layer_index = 0
     new_name = layer_props["name"] + " cropped [0]"
-    # Get existing layer names in viewer
-    names_list = [layer.name for layer in viewer.layers]
+    names_list = []
+    if viewer is not None:
+        # Get existing layer names in viewer
+        names_list = [layer.name for layer in viewer.layers]
     for shape_count, [shape, shape_type] in enumerate(zip(shapes,
                                                           shape_types)):
         # move shape vertices to within image coordinate limits

--- a/napari_crop/_tests/test_function.py
+++ b/napari_crop/_tests/test_function.py
@@ -57,7 +57,7 @@ def test_crop_function_values_2d(make_napari_viewer, shape, shape_type,
     viewer = make_napari_viewer()
     img_layer = viewer.add_image(arr_2d)
     shapes_layer = viewer.add_shapes(shape, shape_type=shape_type)
-    cropped_actual = crop_region(img_layer, shapes_layer)
+    cropped_actual = crop_region(viewer, img_layer, shapes_layer)
     cropped_actual_arrays = [cropped[0] for cropped in cropped_actual][0]
     assert np.array_equal(crop_expected, cropped_actual_arrays)
 
@@ -68,7 +68,7 @@ def test_crop_multiple_shapes(make_napari_viewer):
     viewer = make_napari_viewer()
     img_layer = viewer.add_image(arr_2d)
     shapes_layer = viewer.add_shapes(shapes, shape_type=shape_types)
-    cropped_actual = crop_region(img_layer, shapes_layer)
+    cropped_actual = crop_region(viewer, img_layer, shapes_layer)
 
     assert len(shapes) == len(cropped_actual)
 
@@ -115,7 +115,7 @@ def test_crop_function_nd(layer_data, rgb, layer_type, shape_data, shape_type,
     nlayers = len(viewer.layers)
 
     #  Get first tuple element (data) of first list element (LayerDataTuple)
-    cropped_data = crop_region(layer, shapes_layer)[0][0]
+    cropped_data = crop_region(viewer, layer, shapes_layer)[0][0]
     viewer.add_image(cropped_data)
 
     assert len(viewer.layers) == nlayers + 1

--- a/napari_crop/_tests/test_function.py
+++ b/napari_crop/_tests/test_function.py
@@ -57,7 +57,7 @@ def test_crop_function_values_2d(make_napari_viewer, shape, shape_type,
     viewer = make_napari_viewer()
     img_layer = viewer.add_image(arr_2d)
     shapes_layer = viewer.add_shapes(shape, shape_type=shape_type)
-    cropped_actual = crop_region(viewer, img_layer, shapes_layer)
+    cropped_actual = crop_region(img_layer, shapes_layer)
     cropped_actual_arrays = [cropped[0] for cropped in cropped_actual][0]
     assert np.array_equal(crop_expected, cropped_actual_arrays)
 
@@ -68,7 +68,7 @@ def test_crop_multiple_shapes(make_napari_viewer):
     viewer = make_napari_viewer()
     img_layer = viewer.add_image(arr_2d)
     shapes_layer = viewer.add_shapes(shapes, shape_type=shape_types)
-    cropped_actual = crop_region(viewer, img_layer, shapes_layer)
+    cropped_actual = crop_region(img_layer, shapes_layer, viewer=viewer)
 
     assert len(shapes) == len(cropped_actual)
 
@@ -115,7 +115,7 @@ def test_crop_function_nd(layer_data, rgb, layer_type, shape_data, shape_type,
     nlayers = len(viewer.layers)
 
     #  Get first tuple element (data) of first list element (LayerDataTuple)
-    cropped_data = crop_region(viewer, layer, shapes_layer)[0][0]
+    cropped_data = crop_region(layer, shapes_layer)[0][0]
     viewer.add_image(cropped_data)
 
     assert len(viewer.layers) == nlayers + 1


### PR DESCRIPTION
Hi guys,

This Draft PR is intended to fix #20 .
The problem happened because after #7 because [here](https://github.com/BiAPoL/napari-crop/blob/86b9670fba2c00264cf0c7e68cda020fef06c2e3/napari_crop/_function.py#L104) we always assigned the same name for drawn shapes from the same Shapes layer, thus, napari replaces previous output Image layer data instead of creating a new layer if the function was executed again.

The proposed solution is to always provide a new unique name by checking layer names in the viewer (or layer names about to be added to the viewer in case of multiple shapes).

It works here. I will write a test before turning this into regular PR.

Best,
Marcelo
